### PR TITLE
Fixed the USB requestDevice call

### DIFF
--- a/SpawnDev.BlazorJS/JSObjects/USB.cs
+++ b/SpawnDev.BlazorJS/JSObjects/USB.cs
@@ -26,7 +26,7 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// Returns a Promise that resolves with an instance of USBDevice if the specified device is found. Calling this function triggers the user agent's pairing flow.
         /// </summary>
         /// <returns></returns>
-        public Task<USBDevice> RequestDevice(IEnumerable<USBRequestDeviceFilter> filters) => JSRef!.CallAsync<USBDevice>("requestDevice", filters);
+        public Task<USBDevice> RequestDevice(IEnumerable<USBRequestDeviceFilter> filters) => JSRef!.CallAsync<USBDevice>("requestDevice", new { filters: filters });
         #endregion
 
         #region Events

--- a/SpawnDev.BlazorJS/JSObjects/USB.cs
+++ b/SpawnDev.BlazorJS/JSObjects/USB.cs
@@ -16,7 +16,7 @@ namespace SpawnDev.BlazorJS.JSObjects
         public USB(IJSInProcessObjectReference _ref) : base(_ref) { }
         #endregion
 
-        #region 
+        #region
         /// <summary>
         /// Returns a Promise that resolves with an array of USBDevice objects for paired attached devices.
         /// </summary>
@@ -26,7 +26,7 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// Returns a Promise that resolves with an instance of USBDevice if the specified device is found. Calling this function triggers the user agent's pairing flow.
         /// </summary>
         /// <returns></returns>
-        public Task<USBDevice> RequestDevice(IEnumerable<USBRequestDeviceFilter> filters) => JSRef!.CallAsync<USBDevice>("requestDevice", new { filters: filters });
+        public Task<USBDevice> RequestDevice(IEnumerable<USBRequestDeviceFilter> filters) => JSRef!.CallAsync<USBDevice>("requestDevice", new { filters });
         #endregion
 
         #region Events


### PR DESCRIPTION
The documentation isn't very clear with this - but - the expectation is that you pass an object with a single property "filters" not a list of filters.

https://developer.mozilla.org/en-US/docs/Web/API/USB/requestDevice the example is not very good either as it just creates an object with the property defined.

I'm thinking this minor tweak should fix the problem - without this you'll end up with the following error:

`Unhandled exception rendering component: Failed to execute 'requestDevice' on 'USB': Failed to read the 'filters' property from 'USBDeviceRequestOptions': Required member is undefined.
TypeError: Failed to execute 'requestDevice' on 'USB': Failed to read the 'filters' property from 'USBDeviceRequestOptions': Required member is undefined`