### PR TITLE
Corrected the property names for USBInterface

### DIFF
--- a/SpawnDev.BlazorJS/JSObjects/USBInterface.cs
+++ b/SpawnDev.BlazorJS/JSObjects/USBInterface.cs
@@ -19,16 +19,16 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <summary>
         /// The currently selected alternative configuration of this interface. By default, this is the USBAlternateInterface from alternates with alternateSetting equal to 0. It can be changed by calling USBDevice.selectAlternateInterface() with any other value found in alternates.
         /// </summary>
-        public USBAlternateInterface Alternate => JSRef!.Get<USBAlternateInterface>("interfaceNumber");
+        public USBAlternateInterface Alternate => JSRef!.Get<USBAlternateInterface>("alternate");
 
         /// <summary>
         /// An array containing instances of the USBAlternateInterface interface describing each of the alternative configurations possible for this interface.
         /// </summary>
-        public Array<USBAlternateInterface> Alternates => JSRef!.Get<Array<USBAlternateInterface>>("interfaceNumber");
+        public Array<USBAlternateInterface> Alternates => JSRef!.Get<Array<USBAlternateInterface>>("alternates");
 
         /// <summary>
         /// Whether this interface has been claimed by the current page by calling USBDevice.claimInterface().
         /// </summary>
-        public bool Claimed => JSRef!.Get<bool>("interfaceNumber");
+        public bool Claimed => JSRef!.Get<bool>("claimed");
     }
 }


### PR DESCRIPTION
I accidently left copy 'n' pasted names on the USBInterface class - my bad!