### PR TITLE
Updated WebHID types to match the documentation with all types currently defined

### DIFF
--- a/SpawnDev.BlazorJS/JSObjects/HID.cs
+++ b/SpawnDev.BlazorJS/JSObjects/HID.cs
@@ -25,7 +25,7 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <summary>
         /// Returns a Promise that resolves with an array of connected HIDDevice objects. Calling this function will trigger the user agent's permission flow in order to gain permission to access one selected device from the returned list of devices.
         /// </summary>
-        public Task<Array<HIDDevice>> RequestDevice(HIDRequestDeviceOptions[] options) => JSRef!.CallAsync<Array<HIDDevice>>("requestDevice", options);
+        public Task<Array<HIDDevice>> RequestDevice(HIDDeviceRequestOptions options) => JSRef!.CallAsync<Array<HIDDevice>>("requestDevice", options);
         #endregion
 
         #region Events

--- a/SpawnDev.BlazorJS/JSObjects/HIDCollectionInfo.cs
+++ b/SpawnDev.BlazorJS/JSObjects/HIDCollectionInfo.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.JSInterop;
+
+namespace SpawnDev.BlazorJS.JSObjects
+{
+    /// <summary>
+    /// The HIDCollectionInfo interface of the WebHID API represents a collection of HID reports and their associated metadata.
+    /// https://developer.mozilla.org/en-US/docs/Web/API/HIDDevice/collections
+    /// </summary>
+    public class HIDCollectionInfo : JSObject
+    {
+        public HIDCollectionInfo(IJSInProcessObjectReference _ref) : base(_ref)
+        {
+        }
+
+        /// <summary>
+        /// An integer representing the usage page component of the HID usage associated with this collection. The usage for a top level collection is used to identify the device type.
+        /// </summary>
+        public int UsagePage => JSRef!.Get<int>("usagePage");
+
+        /// <summary>
+        /// An integer representing the usage ID component of the HID usage associated with this collection.
+        /// </summary>
+        public int Usage => JSRef!.Get<int>("usage");
+
+        /// <summary>
+        /// An 8-bit value representing the collection type, which describes a different relationship between the grouped items.
+        /// It can be one of the following values:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term>0x00</term>
+        ///         <description>Physical (group of axes)</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0x01</term>
+        ///         <description>Application (mouse, keyboard)</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0x02</term>
+        ///         <description>Logical (interrelated data)</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0x03</term>
+        ///         <description>Report</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0x04</term>
+        ///         <description>Named array</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0x05</term>
+        ///         <description>Usage switch</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0x06</term>
+        ///         <description>Usage modified</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0x07 to 0x7F</term>
+        ///         <description>Reserved for future use</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>0x80 to 0xFF</term>
+        ///         <description>Vendor-defined</description>
+        ///     </item>
+        /// </list>
+        /// </summary>
+        public byte Type => JSRef.Get<byte>("type");
+
+        /// <summary>
+        /// An array of sub-collections which takes the same format as a top-level collection.
+        /// </summary>
+        public HIDCollectionInfo[] Children => JSRef!.Get<HIDCollectionInfo[]>("children");
+
+        /// <summary>
+        /// An array of inputReport items which represent individual input reports described in this collection.
+        /// </summary>
+        public HIDReportInfo[] InputReports => JSRef!.Get<HIDReportInfo[]>("inputReports");
+
+        /// <summary>
+        /// An array of outputReport items which represent individual output reports described in this collection.
+        /// </summary>
+        public HIDReportInfo[] OutputReports => JSRef!.Get<HIDReportInfo[]>("outputReports");
+
+        /// <summary>
+        /// An array of featureReport items which represent individual feature reports described in this collection.
+        /// </summary>
+        public HIDReportInfo[] FeatureReports => JSRef!.Get<HIDReportInfo[]>("featureReports");
+    }
+}

--- a/SpawnDev.BlazorJS/JSObjects/HIDDevice.cs
+++ b/SpawnDev.BlazorJS/JSObjects/HIDDevice.cs
@@ -3,12 +3,96 @@
 namespace SpawnDev.BlazorJS.JSObjects
 {
     /// <summary>
-    /// The HIDDevice interface of the WebHID API represents a HID Device. It provides properties for accessing information about the device, methods for opening and closing the connection, and the sending and receiving of reports.<br/>
+    /// The HIDDevice interface of the WebHID API represents a HID Device. It provides properties for accessing information about the device, methods for opening and closing the connection, and the sending and receiving of reports.
     /// https://developer.mozilla.org/en-US/docs/Web/API/HIDDevice
     /// </summary>
     public class HIDDevice : EventTarget
     {
-        public HIDDevice(IJSInProcessObjectReference _ref) : base(_ref) { }
-        // TODO finish
+        #region Constructors
+
+        public HIDDevice(IJSInProcessObjectReference _ref) : base(_ref)
+        {
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns a boolean, true if the device has an open connection.
+        /// </summary>
+        public bool Opened => JSRef!.Get<bool>("opened");
+
+        /// <summary>
+        /// Returns the vendorId of the HID device.
+        /// </summary>
+        public int VendorId => JSRef!.Get<int>("vendorId");
+
+        /// <summary>
+        /// Returns the productId of the HID device.
+        /// </summary>
+        public int ProductId => JSRef!.Get<int>("productId");
+
+        /// <summary>
+        /// Returns a string containing the product name of the HID device.
+        /// </summary>
+        public string ProductName => JSRef!.Get<string>("productName");
+
+        /// <summary>
+        /// Returns an array of report formats for the HID device.
+        /// </summary>
+        public Array<HIDCollectionInfo> Collections => JSRef!.Get<Array<HIDCollectionInfo>>("collections");
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Opens a connection to this HID device, and returns a Promise which resolves once the connection has been successful.
+        /// </summary>
+        public Task Open() => JSRef!.CallVoidAsync("open");
+
+        /// <summary>
+        /// Closes the connection to this HID device, and returns a Promise which resolves once the connection has been closed.
+        /// </summary>
+
+        public Task Close() => JSRef!.CallVoidAsync("close");
+
+        /// <summary>
+        /// Closes the connection to this HID device and resets access permission, and returns a Promise which resolves once the permission was reset.
+        /// </summary>
+
+        public Task Forget() => JSRef!.CallVoidAsync("forget");
+
+        /// <summary>
+        /// Sends an output report to this HID Device, and returns a Promise which resolves once the report has been sent.
+        /// </summary>
+        /// <param name="reportId">An 8-bit report ID. If the HID device does not use report IDs, send 0.</param>
+        /// <param name="data">Bytes as an ArrayBuffer, a TypedArray, or a DataView.</param>
+        public Task SendReport(byte reportId, byte[] data) => JSRef!.CallVoidAsync("sendReport", reportId, data);
+
+        /// <summary>
+        /// Sends a feature report to this HID device, and returns a Promise which resolves once the report has been sent.
+        /// </summary>
+        /// <param name="reportId">An 8-bit report ID. If the HID device does not use report IDs, send 0.</param>
+        /// <param name="data">Bytes as an ArrayBuffer, a TypedArray, or a DataView.</param>
+        public Task SendFeatureReport(byte reportId, byte[] data) => JSRef!.CallVoidAsync("sendFeatureReport", reportId, data);
+
+        /// <summary>
+        /// Receives a feature report from this HID device in the form of a Promise which resolves with a DataView. This allows typed access to the contents of this message.
+        /// </summary>
+        /// <param name="reportId">An 8-bit report ID. If the HID device does not use report IDs, send 0.</param>
+        public Task<DataView> ReceiveFeatureReport(byte reportId) => JSRef!.CallAsync<DataView>("receiveFeatureReport", reportId);
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Fires when a report is sent from the device.
+        /// </summary>
+        public ActionEvent<HIDInputReportEvent> OnInputReport { get => new ActionEvent<HIDInputReportEvent>("inputreport", AddEventListener, RemoveEventListener); set { } }
+
+        #endregion
     }
 }

--- a/SpawnDev.BlazorJS/JSObjects/HIDDeviceFilter.cs
+++ b/SpawnDev.BlazorJS/JSObjects/HIDDeviceFilter.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SpawnDev.BlazorJS.JSObjects
+{
+    /// <summary>
+    /// HID Device filter options
+    /// https://developer.mozilla.org/en-US/docs/Web/API/HID/requestDevice#parameters
+    /// </summary>
+    public class HIDDeviceFilter
+    {
+        /// <summary>
+        /// An integer representing the vendorId of the requested HID device
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? VendorId { get; set; }
+        /// <summary>
+        /// An integer representing the productId of the requested HID device.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? ProductId { get; set; }
+        /// <summary>
+        /// An integer representing the usage page component of the HID usage of the requested device. The usage for a top level collection is used to identify the device type.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? UsagePage { get; set; }
+        /// <summary>
+        /// An integer representing the usage ID component of the HID usage of the requested device.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? Usage { get; set; }
+    }
+}

--- a/SpawnDev.BlazorJS/JSObjects/HIDInputReportEvent.cs
+++ b/SpawnDev.BlazorJS/JSObjects/HIDInputReportEvent.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.JSInterop;
+
+namespace SpawnDev.BlazorJS.JSObjects
+{
+    /// <summary>
+    /// Represents a HIDInputReportEvent fired by a HID device.
+    /// This event contains the report data received from a HID device.
+    /// Corresponds to the WebHID 'HIDInputReportEvent' interface.
+    /// https://wicg.github.io/webhid/#hidinputreportevent-interface
+    /// </summary>
+    public class HIDInputReportEvent : Event
+    {
+        public HIDInputReportEvent(IJSInProcessObjectReference _ref) : base(_ref)
+        {
+        }
+
+        /// <summary>
+        /// The HIDDevice object associated with this event, representing the device
+        /// that sent the input report.
+        /// </summary>
+        public HIDDevice Device => new HIDDevice(JSRef!.Get<IJSInProcessObjectReference>("device"));
+
+        /// <summary>
+        /// An 8-bit value indicating the report ID of the input report.
+        /// A value of 0 means the device does not use report IDs.
+        /// </summary>
+        public byte ReportId => JSRef!.Get<byte>("reportId");
+
+        /// <summary>
+        /// A DataView object containing the raw input report data.
+        /// </summary>
+        public DataView Data => JSRef!.Get<DataView>("data");
+    }
+}

--- a/SpawnDev.BlazorJS/JSObjects/HIDReportInfo.cs
+++ b/SpawnDev.BlazorJS/JSObjects/HIDReportInfo.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.JSInterop;
+
+namespace SpawnDev.BlazorJS.JSObjects
+{
+    /// <summary>
+    /// A HIDReportInfo represents one input, output, or feature report within the report descriptor.
+    /// https://wicg.github.io/webhid/#dom-hidreportinfo
+    /// </summary>
+    public class HIDReportInfo : JSObject
+    {
+        public HIDReportInfo(IJSInProcessObjectReference _ref) : base(_ref)
+        {
+        }
+
+        /// <summary>
+        /// A HID interface uses report IDs if it prepends a one-byte identification prefix to each report transfer. The reportId member is the prefix for this report if the interface uses report IDs, or 0 otherwise.
+        /// </summary>
+        public byte ReportId => JSRef!.Get<byte>("reportId");
+
+        /// <summary>
+        /// A sequence of HIDReportItem representing the fields of this report.
+        /// </summary>
+        public IEnumerable<HIDReportItem> Items => JSRef!.Get<IEnumerable<HIDReportItem>>("items");
+    }
+}

--- a/SpawnDev.BlazorJS/JSObjects/HIDReportItem.cs
+++ b/SpawnDev.BlazorJS/JSObjects/HIDReportItem.cs
@@ -1,0 +1,215 @@
+﻿using Microsoft.JSInterop;
+
+namespace SpawnDev.BlazorJS.JSObjects
+{
+    /// <summary>
+    /// A HIDReportItem represents one field within a HID report.
+    /// https://wicg.github.io/webhid/#hidreportitem-dictionary
+    /// </summary>
+    public class HIDReportItem : JSObject
+    {
+        public HIDReportItem(IJSInProcessObjectReference _ref) : base(_ref)
+        {
+        }
+
+        /// <summary>
+        /// true if the data is absolute (based on a fixed origin), or false if the data is relative
+        /// (indicating the change in value from the last report).
+        /// </summary>
+        public bool IsAbsolute => JSRef!.Get<bool>("isAbsolute");
+
+        /// <summary>
+        /// true if the item creates array data fields in reports where each data field contains an index
+        /// corresponding to a pressed button or key, or false if the item creates variable data fields
+        /// in reports where each data field contains a value.
+        /// </summary>
+        public bool IsArray => JSRef!.Get<bool>("isArray");
+
+        /// <summary>
+        /// true if the item emits a fixed-sized stream of bytes, or false if the item is a numeric
+        /// quantity.
+        /// </summary>
+        public bool IsBufferedBytes => JSRef!.Get<bool>("isBufferedBytes");
+
+        /// <summary>
+        /// true if the item is a static read-only field and cannot be modified, or false if the item
+        /// defines report fields that contain modifiable device data.
+        /// </summary>
+        public bool IsConstant => JSRef!.Get<bool>("isConstant");
+
+        /// <summary>
+        /// true if the item represents a linear relationship between what is measured and what is
+        /// reported, or false if the data has been processed in some way.
+        /// </summary>
+        public bool IsLinear => JSRef!.Get<bool>("isLinear");
+
+        /// <summary>
+        /// true if the item assigns usages from a HID usage range defined by usageMinimum and
+        /// usageMaximum, or false if the item has a sequence of HID usage values in usages.
+        /// </summary>
+        public bool IsRange => JSRef!.Get<bool>("isRange");
+
+        /// <summary>
+        /// true if the item value can change without host interaction, or false if the item value
+        /// should only be changed by the host. Only used for Feature and Output items.
+        /// </summary>
+        public bool IsVolatile => JSRef!.Get<bool>("isVolatile");
+
+        /// <summary>
+        /// true if the item has a null state in which it is not sending meaningful data, or false if
+        /// it does not have a null state. When in a null state, the item will report a value outside
+        /// of the specified logicalMinimum and logicalMaximum.
+        /// </summary>
+        public bool HasNull => JSRef!.Get<bool>("hasNull");
+
+        /// <summary>
+        /// true if the item has a preferred state to which it will return when the user is not
+        /// physically interacting with the control, or false if the item does not have a preferred
+        /// state.
+        /// </summary>
+        public bool HasPreferredState => JSRef!.Get<bool>("hasPreferredState");
+
+        /// <summary>
+        /// true if the item value rolls over when reaching either the extreme high or low value, or
+        /// false if the item value does not roll over.
+        /// </summary>
+        public bool Wrap => JSRef!.Get<bool>("wrap");
+
+        /// <summary>
+        /// If isRange is true or this item has no associated HID usage values, then usages MUST be
+        /// undefined. If isRange is false then usages is a sequence of HID usage values associated
+        /// with this item.
+        /// </summary>
+        public IEnumerable<uint> Usages => JSRef!.Get<IEnumerable<uint>>("usages");
+
+        /// <summary>
+        /// If isRange is true then usageMinimum contains the minimum HID usage value in the usage range
+        /// associated with this item. If isRange is false then usageMinimum MUST be undefined.
+        /// </summary>
+        public uint UsageMinimum => JSRef!.Get<uint>("usageMinimum");
+
+        /// <summary>
+        /// If isRange is true then usageMaximum contains the maximum HID usage value in the usage range
+        /// associated with this item. If isRange is false then usageMaximum MUST be undefined.
+        /// </summary>
+        public uint UsageMaximum => JSRef!.Get<uint>("usageMaximum");
+
+        /// <summary>
+        /// The size of each report data field in bits. The reportSize MUST be greater than 0.
+        /// </summary>
+        public ushort ReportSize => JSRef!.Get<ushort>("reportSize");
+
+        /// <summary>
+        /// The number of fields included in the report for this item. The reportCount MUST be greater
+        /// than 0.
+        /// </summary>
+        public ushort ReportCount => JSRef!.Get<ushort>("reportCount");
+
+        /// <summary>
+        /// The value of the unit exponent, or 0 if the item has no unit definition.
+        /// </summary>
+        public byte UnitExponent => JSRef!.Get<byte>("unitExponent");
+
+        /// <summary>
+        /// A string value specifying the unit system for the unit definition.
+        /// This property will have one of the following string values:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term>"none"</term>
+        ///         <description>No unit system. Indicates that the item does not have a unit definition.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>"si-linear"</term>
+        ///         <description>The SI Linear unit system uses centimeter, gram, second, Kelvin, Ampere, Candela.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>"si-rotation"</term>
+        ///         <description>The SI Rotation unit system uses radian, gram, second, Kelvin, Ampere, Candela.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>"english-linear"</term>
+        ///         <description>The English Linear unit system uses inch, slug, second, degree Fahrenheit, Ampere, Candela.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>"english-rotation"</term>
+        ///         <description>The English Rotation unit system uses degree, slug, second, degree Fahrenheit, Ampere, Candela.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>"vendor-defined"</term>
+        ///         <description>A vendor-defined unit system.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>"reserved"</term>
+        ///         <description>Indicates that the device used a reserved value for its unit system.</description>
+        ///     </item>
+        /// </list>
+        /// </summary>
+        public string UnitSystem => JSRef!.Get<string>("unitSystem");
+
+        /// <summary>
+        /// The value of the exponent for the length unit (centimeters, radians, inch, or degrees) in
+        /// the unit definition, or 0 if the item has no unit definition.
+        /// </summary>
+        public byte UnitFactorLengthExponent => JSRef!.Get<byte>("unitFactorLengthExponent");
+
+        /// <summary>
+        /// The value of the exponent for the mass unit (gram or slug) in the unit definition, or 0 if
+        /// the item has no unit definition.
+        /// </summary>
+        public byte UnitFactorMassExponent => JSRef!.Get<byte>("unitFactorMassExponent");
+
+        /// <summary>
+        /// The value of the exponent for the time unit (seconds) in the unit definition, or 0 if the
+        /// item has no unit definition.
+        /// </summary>
+        public byte UnitFactorTimeExponent => JSRef!.Get<byte>("unitFactorTimeExponent");
+
+        /// <summary>
+        /// The value of the exponent for the temperature unit (Kelvin or degrees Fahrenheit) in the
+        /// unit definition, or 0 if the item has no unit definition.
+        /// </summary>
+        public byte UnitFactorTemperatureExponent => JSRef!.Get<byte>("unitFactorTemperatureExponent");
+
+        /// <summary>
+        /// The value of the exponent for the electrical current unit (Ampere) in the unit definition,
+        /// or 0 if the item has no unit definition.
+        /// </summary>
+        public byte UnitFactorCurrentExponent => JSRef!.Get<byte>("unitFactorCurrentExponent");
+
+        /// <summary>
+        /// The value of the exponent for the luminous intensity unit (Candela) in the unit definition,
+        /// or 0 if the item has no unit definition.
+        /// </summary>
+        public byte UnitFactorLuminousIntensityExponent => JSRef!.Get<byte>("unitFactorLuminousIntensityExponent");
+
+        /// <summary>
+        /// The minimum extent of this item in logical units. This is the minimum value that a variable
+        /// or array item will report.
+        /// </summary>
+        public long LogicalMinimum => JSRef!.Get<long>("logicalMinimum");
+
+        /// <summary>
+        /// The maximum extent of this item in logical units. This is the maximum value that a variable
+        /// or array item wll report.
+        /// </summary>
+        public long LogicalMaximum => JSRef!.Get<long>("logicalMaximum");
+
+        /// <summary>
+        /// The minimum value for the physical extent of this item. This represents the logicalMinimum
+        /// with units applied to it.
+        /// </summary>
+        public long PhysicalMinimum => JSRef!.Get<long>("physicalMinimum");
+
+        /// <summary>
+        /// The maximum value for the physical extent of this item. This represents the logicalMaximum
+        /// with units applied to it.
+        /// </summary>
+        public long PhysicalMaximum => JSRef!.Get<long>("physicalMaximum");
+
+        /// <summary>
+        /// The strings associated with this item, or an empty sequence if no strings are associated
+        /// with this item.
+        /// </summary>
+        public IEnumerable<string> Strings => JSRef!.Get<IEnumerable<string>>("strings");
+    }
+}

--- a/SpawnDev.BlazorJS/JSObjects/HIDRequestDeviceOptions.cs
+++ b/SpawnDev.BlazorJS/JSObjects/HIDRequestDeviceOptions.cs
@@ -3,29 +3,21 @@
 namespace SpawnDev.BlazorJS.JSObjects
 {
     /// <summary>
-    /// HID RequestDevice options
+    /// HID Device request options
+    /// https://wicg.github.io/webhid/#dom-hid-requestdevice
     /// </summary>
-    public class HIDRequestDeviceOptions
+    public class HIDDeviceRequestOptions
     {
         /// <summary>
-        /// An integer representing the vendorId of the requested HID device
+        /// An array of HIDDeviceFilter objects used to filter the requested devices.
         /// </summary>
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public int? VendorId { get; set; }
+        public IEnumerable<HIDDeviceFilter> Filters { get; set; }
+
         /// <summary>
-        /// An integer representing the productId of the requested HID device.
+        /// An optional array of HIDDeviceFilter objects used to exclude devices from the requested devices.
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public int? ProductId { get; set; }
-        /// <summary>
-        /// An integer representing the usage page component of the HID usage of the requested device. The usage for a top level collection is used to identify the device type.
-        /// </summary>
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public int? UsagePage { get; set; }
-        /// <summary>
-        /// An integer representing the usage ID component of the HID usage of the requested device.
-        /// </summary>
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public int? Usage { get; set; }
+        public IEnumerable<HIDDeviceFilter>? ExclusionFilters { get; set; }
+
     }
 }


### PR DESCRIPTION
I've gone through and updated the existing WebHID types as far as i can to the best of my abilities, i've also tried to maintain the structure used elsewhere (primarily looked at WebUSB and compared to it and tried to follow that)

I haven't been able to test this out yet, but i do have a device i'm working on that uses some of these features which i will be testing this with soon. However, i believe that it should be working as-is since it follows the specs and is similar to the WebUSB i worked on before.