### PR TITLE
Fixed data type used in CanvasRenderingContext2D and ImageData

### DIFF
--- a/SpawnDev.BlazorJS/JSObjects/CanvasRenderingContext2D.cs
+++ b/SpawnDev.BlazorJS/JSObjects/CanvasRenderingContext2D.cs
@@ -15,22 +15,27 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// </summary>
         /// <param name="_ref"></param>
         public CanvasRenderingContext2D(IJSInProcessObjectReference _ref) : base(_ref) { }
+
         /// <summary>
         /// Image smoothing mode; if disabled, images will not be smoothed if scaled.
         /// </summary>
         public bool ImageSmoothingEnabled { get => JSRef!.Get<bool>("imageSmoothingEnabled"); set => JSRef!.Set("imageSmoothingEnabled", value); }
+
         /// <summary>
         /// The CanvasRenderingContext2D.canvas property, part of the Canvas API, is a read-only reference to the HTMLCanvasElement object that is associated with a given context. It might be null if there is no associated canvas element.
         /// </summary>
         public HTMLCanvasElement Canvas => JSRef!.Get<HTMLCanvasElement>("canvas");
+
         /// <summary>
         /// Color or style to use inside shapes. Default #000 (black).
         /// </summary>
         public string FillStyle { get => JSRef!.Get<string>("fillStyle"); set => JSRef!.Set("fillStyle", value); }
+
         /// <summary>
         /// The CanvasRenderingContext2D.lineCap property of the Canvas 2D API determines the shape used to draw the end points of lines.
         /// </summary>
         public string LineCap { get => JSRef!.Get<string>("lineCap"); set => JSRef!.Set("lineCap", value); }
+
         /// <summary>
         /// The CanvasRenderingContext2D.lineJoin property of the Canvas 2D API determines the shape used to join two line segments where they meet.
         /// </summary>
@@ -196,45 +201,21 @@ namespace SpawnDev.BlazorJS.JSObjects
             using var canvas = Canvas;
             return GetImageData(0, 0, canvas.Width, canvas.Height);
         }
-        /// <summary>
-        /// Returns an ImageData object representing the underlying pixel data for the area of the canvas denoted by the rectangle which starts at (sx, sy) and has an sw width and sh height.
-        /// </summary>
-        /// <param name="x"></param>
-        /// <param name="y"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <returns></returns>
-        public ImageData GetImageData(int x, int y, int width, int height) => JSRef!.Call<ImageData>("getImageData", x, y, width, height);
-        /// <summary>
-        /// The CanvasRenderingContext2D.putImageData() method of the Canvas 2D API paints data from the given ImageData object onto the canvas. If a dirty rectangle is provided, only the pixels from that rectangle are painted. This method is not affected by the canvas transformation matrix.
-        /// </summary>
-        /// <param name="imageData"></param>
-        /// <param name="dx"></param>
-        /// <param name="dy"></param>
-        public void PutImageData(ImageData imageData, int dx, int dy) => JSRef!.CallVoid("putImageData", imageData, dx, dy);
-        /// <summary>
-        /// The CanvasRenderingContext2D.putImageData() method of the Canvas 2D API paints data from the given ImageData object onto the canvas. If a dirty rectangle is provided, only the pixels from that rectangle are painted. This method is not affected by the canvas transformation matrix.
-        /// </summary>
-        /// <param name="imageData"></param>
-        /// <param name="dx"></param>
-        /// <param name="dy"></param>
-        /// <param name="dirtyX"></param>
-        /// <param name="dirtyY"></param>
-        /// <param name="dirtyWidth"></param>
-        /// <param name="dirtyHeight"></param>
-        public void PutImageData(ImageData imageData, int dx, int dy, int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight) => JSRef!.CallVoid("putImageData", imageData, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
+
         /// <summary>
         /// The CanvasRenderingContext2D.font property of the Canvas 2D API specifies the current text style to use when drawing text. This string uses the same syntax as the CSS font specifier.
         /// </summary>
         public string Font { get => JSRef!.Get<string>("font"); set => JSRef!.Set("font", value); }
+
         /// <summary>
         /// The CanvasRenderingContext2D.measureText() method returns a TextMetrics object that contains information about the measured text (such as its width, for example).
         /// </summary>
         /// <param name="text"></param>
         /// <returns></returns>
         public TextMetrics MeasureText(string text) => JSRef!.Call<TextMetrics>("measureText", text);
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <returns></returns>
         public byte[]? GetImageBytes()
@@ -242,6 +223,7 @@ namespace SpawnDev.BlazorJS.JSObjects
             using var canvas = Canvas;
             return GetImageBytes(0, 0, canvas.Width, canvas.Height);
         }
+
         /// <summary>
         /// Returns a byte[] from GetImageData
         /// </summary>
@@ -250,7 +232,7 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="width"></param>
         /// <param name="height"></param>
         /// <returns></returns>
-        public byte[]? GetImageBytes(int x, int y, int width, int height)
+        public byte[]? GetImageBytes(double x, double y, double width, double height)
         {
             byte[]? ret = null;
             using ImageData? frameData = GetImageData(x, y, width, height);
@@ -261,6 +243,7 @@ namespace SpawnDev.BlazorJS.JSObjects
             }
             return ret;
         }
+
         /// <summary>
         /// PutImageData using byte[]
         /// </summary>
@@ -269,30 +252,33 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="srcHeight"></param>
         /// <param name="dx"></param>
         /// <param name="dy"></param>
-        public void PutImageBytes(byte[] srcBytes, int srcWidth, int srcHeight, int dx = 0, int dy = 0)
+        public void PutImageBytes(byte[] srcBytes, double srcWidth, double srcHeight, double dx = 0, double dy = 0)
         {
-            // using a SharedByteClampedArray prevents a copy of the data from being made before the draw. 
+            // using a SharedByteClampedArray prevents a copy of the data from being made before the draw.
             using var sharedUint8Array = (HeapView)srcBytes;
             using var imageData = new ImageData(sharedUint8Array, srcWidth, srcHeight);
             PutImageData(imageData, dx, dy);
         }
+
         /// <summary>
         /// PutImageData using byte[]
         /// </summary>
-        public void PutImageBytes(byte[] imageBytes, int srcWidth, int srcHeight, int dx, int dy, int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight)
+        public void PutImageBytes(byte[] imageBytes, double srcWidth, double srcHeight, double dx, double dy, double dirtyX, double dirtyY, double dirtyWidth, double dirtyHeight)
         {
-            // using a new SharedByteClampedArray prevents a copy of the data from being made before the draw. 
+            // using a new SharedByteClampedArray prevents a copy of the data from being made before the draw.
             using var sharedUint8Array = (HeapView)imageBytes;
             using var imageData = new ImageData(sharedUint8Array, srcWidth, srcHeight);
             PutImageData(imageData, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
         }
+
         /// <summary>
         /// Draws the specified image. This method is available in multiple formats, providing a great deal of flexibility in its use.
         /// </summary>
         /// <param name="imageData">An element to draw into the context. The specification permits any canvas image source, specifically, an HTMLImageElement, an SVGImageElement, an HTMLVideoElement, an HTMLCanvasElement, an ImageBitmap, an OffscreenCanvas, or a VideoFrame.</param>
         /// <param name="dx">The x-axis coordinate in the destination canvas at which to place the top-left corner of the source image.</param>
         /// <param name="dy">The y-axis coordinate in the destination canvas at which to place the top-left corner of the source image.</param>
-        public void DrawImage(CanvasImageSource imageData, int dx = 0, int dy = 0) => JSRef!.CallVoid("drawImage", imageData, dx, dy);
+        public void DrawImage(CanvasImageSource imageData, double dx = 0, double dy = 0) => JSRef!.CallVoid("drawImage", imageData, dx, dy);
+
         /// <summary>
         /// Draws the specified image. This method is available in multiple formats, providing a great deal of flexibility in its use.
         /// </summary>
@@ -301,7 +287,8 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="dy">The y-axis coordinate in the destination canvas at which to place the top-left corner of the source image.</param>
         /// <param name="dWidth">The width to draw the image in the destination canvas. This allows scaling of the drawn image. If not specified, the image is not scaled in width when drawn. Note that this argument is not included in the 3-argument syntax.</param>
         /// <param name="dHeight">The height to draw the image in the destination canvas. This allows scaling of the drawn image. If not specified, the image is not scaled in height when drawn. Note that this argument is not included in the 3-argument syntax.</param>
-        public void DrawImage(CanvasImageSource imageData, int dx, int dy, int dWidth, int dHeight) => JSRef!.CallVoid("drawImage", imageData, dx, dy, dWidth, dHeight);
+        public void DrawImage(CanvasImageSource imageData, double dx, double dy, double dWidth, double dHeight) => JSRef!.CallVoid("drawImage", imageData, dx, dy, dWidth, dHeight);
+
         /// <summary>
         /// Draws the specified image. This method is available in multiple formats, providing a great deal of flexibility in its use.
         /// </summary>
@@ -314,7 +301,8 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="dy">The y-axis coordinate in the destination canvas at which to place the top-left corner of the source image.</param>
         /// <param name="dWidth">The width to draw the image in the destination canvas. This allows scaling of the drawn image. If not specified, the image is not scaled in width when drawn. Note that this argument is not included in the 3-argument syntax.</param>
         /// <param name="dHeight">The height to draw the image in the destination canvas. This allows scaling of the drawn image. If not specified, the image is not scaled in height when drawn. Note that this argument is not included in the 3-argument syntax.</param>
-        public void DrawImage(CanvasImageSource imageData, int sx, int sy, int sWidth, int sHeight, int dx, int dy, int dWidth, int dHeight) => JSRef!.CallVoid("drawImage", imageData, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+        public void DrawImage(CanvasImageSource imageData, double sx, double sy, double sWidth, double sHeight, double dx, double dy, double dWidth, double dHeight) => JSRef!.CallVoid("drawImage", imageData, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+
         /// <summary>
         /// Draws a filled rectangle at (x, y) position whose size is determined by width and height.
         /// </summary>
@@ -322,7 +310,8 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="y">The y-axis coordinate of the rectangle's starting point.</param>
         /// <param name="width">The rectangle's width. Positive values are to the right, and negative to the left.</param>
         /// <param name="height">The rectangle's height. Positive values are down, and negative are up.</param>
-        public void FillRect(int x, int y, int width, int height) => JSRef!.CallVoid("fillRect", x, y, width, height);
+        public void FillRect(double x, double y, double width, double height) => JSRef!.CallVoid("fillRect", x, y, width, height);
+
         /// <summary>
         /// Sets all pixels in the rectangle defined by starting point (x, y) and size (width, height) to transparent black, erasing any previously drawn content.
         /// </summary>
@@ -330,7 +319,8 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="y">The y-axis coordinate of the rectangle's starting point.</param>
         /// <param name="width">The rectangle's width. Positive values are to the right, and negative to the left.</param>
         /// <param name="height">The rectangle's height. Positive values are down, and negative are up.</param>
-        public void ClearRect(int x, int y, int width, int height) => JSRef!.CallVoid("clearRect", x, y, width, height);
+        public void ClearRect(double x, double y, double width, double height) => JSRef!.CallVoid("clearRect", x, y, width, height);
+
         /// <summary>
         /// Paints a rectangle which has a starting point at (x, y) and has a w width and an h height onto the canvas, using the current stroke style.
         /// </summary>
@@ -338,14 +328,16 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="y">The y-axis coordinate of the rectangle's starting point.</param>
         /// <param name="width">The rectangle's width. Positive values are to the right, and negative to the left.</param>
         /// <param name="height">The rectangle's height. Positive values are down, and negative are up.</param>
-        public void StrokeRect(int x, int y, int width, int height) => JSRef!.CallVoid("strokeRect", x, y, width, height);
+        public void StrokeRect(double x, double y, double width, double height) => JSRef!.CallVoid("strokeRect", x, y, width, height);
+
         /// <summary>
         /// Fills a given text at the given (x,y) position. Optionally with a maximum width to draw.
         /// </summary>
         /// <param name="text"></param>
         /// <param name="x"></param>
         /// <param name="y"></param>
-        public void FillText(string text, int x, int y) => JSRef!.CallVoid("fillText", text, x, y);
+        public void FillText(string text, double x, double y) => JSRef!.CallVoid("fillText", text, x, y);
+
         /// <summary>
         /// Fills a given text at the given (x,y) position. Optionally with a maximum width to draw.
         /// </summary>
@@ -353,14 +345,16 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="maxWidth"></param>
-        public void FillText(string text, int x, int y, int maxWidth) => JSRef!.CallVoid("fillText", text, x, y, maxWidth);
+        public void FillText(string text, double x, double y, double maxWidth) => JSRef!.CallVoid("fillText", text, x, y, maxWidth);
+
         /// <summary>
         /// Draws (strokes) a given text at the given (x, y) position.
         /// </summary>
         /// <param name="text"></param>
         /// <param name="x"></param>
         /// <param name="y"></param>
-        public void StrokeText(string text, int x, int y) => JSRef!.CallVoid("strokeText", text, x, y);
+        public void StrokeText(string text, double x, double y) => JSRef!.CallVoid("strokeText", text, x, y);
+
         /// <summary>
         /// Draws (strokes) a given text at the given (x, y) position.
         /// </summary>
@@ -368,14 +362,15 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="maxWidth"></param>
-        public void StrokeText(string text, int x, int y, int maxWidth) => JSRef!.CallVoid("strokeText", text, x, y, maxWidth);
+        public void StrokeText(string text, double x, double y, double maxWidth) => JSRef!.CallVoid("strokeText", text, x, y, maxWidth);
+
         /// <summary>
         /// The CanvasRenderingContext2D.createImageData() method of the Canvas 2D API creates a new, blank ImageData object with the specified dimensions. All of the pixels in the new object are transparent black.
         /// </summary>
         /// <param name="width">The width to give the new ImageData object. A negative value flips the rectangle around the vertical axis.</param>
         /// <param name="height">The height to give the new ImageData object. A negative value flips the rectangle around the horizontal axis.</param>
-        /// <returns></returns>
-        public ImageData CreateImageData(int width, int height) => JSRef!.Call<ImageData>("createImageData", width, height);
+        public ImageData CreateImageData(double width, double height) => JSRef!.Call<ImageData>("createImageData", width, height);
+
         /// <summary>
         /// The CanvasRenderingContext2D.createImageData() method of the Canvas 2D API creates a new, blank ImageData object with the specified dimensions. All of the pixels in the new object are transparent black.
         /// </summary>
@@ -383,13 +378,15 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="height">The height to give the new ImageData object. A negative value flips the rectangle around the horizontal axis.</param>
         /// <param name="settings"></param>
         /// <returns></returns>
-        public ImageData CreateImageData(int width, int height, ImageDataSettings settings) => JSRef!.Call<ImageData>("createImageData", width, height, settings);
+        public ImageData CreateImageData(double width, double height, ImageDataSettings settings) => JSRef!.Call<ImageData>("createImageData", width, height, settings);
+
         /// <summary>
         /// The CanvasRenderingContext2D.createImageData() method of the Canvas 2D API creates a new, blank ImageData object with the specified dimensions. All of the pixels in the new object are transparent black.
         /// </summary>
         /// <param name="imageData">An existing ImageData object from which to copy the width and height. The image itself is not copied.</param>
         /// <returns></returns>
         public ImageData CreateImageData(ImageData imageData) => JSRef!.Call<ImageData>("createImageData", imageData);
+
         /// <summary>
         /// The CanvasRenderingContext2D.beginPath() method of the Canvas 2D API starts a new path by emptying the list of sub-paths.
         /// </summary>
@@ -587,6 +584,7 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// The CanvasRenderingContext2D.restore() method of the Canvas 2D API restores the most recently saved canvas state by popping the top entry in the drawing state stack. If there is no saved state, this method does nothing.
         /// </summary>
         public void Restore() => JSRef!.CallVoid("restore");
+
         /// <summary>
         /// The CanvasRenderingContext2D.getLineDash() method of the Canvas 2D API returns the current line dash pattern array containing an even number of non-negative numbers.
         /// </summary>
@@ -736,13 +734,6 @@ namespace SpawnDev.BlazorJS.JSObjects
         public void PutImageData(ImageData imagedata, double dx, double dy, double dirtyX, double dirtyY, double dirtyWidth, double dirtyHeight) => JSRef!.CallVoid("putImageData", imagedata, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
 
         /// <summary>
-        /// The CanvasRenderingContext2D.createImageData() method of the Canvas 2D API creates a new, blank ImageData object with the specified dimensions. All of the pixels in the new object are transparent black.
-        /// </summary>
-        /// <param name="sw">The width to give the new ImageData object.</param>
-        /// <param name="sh">The height to give the new ImageData object.</param>
-        /// <returns>A new ImageData object with the specified dimensions.</returns>
-        public ImageData CreateImageData(double sw, double sh) => JSRef!.Call<ImageData>("createImageData", sw, sh);
-        /// <summary>
         /// The CanvasRenderingContext2D.getImageData() method of the Canvas 2D API returns an ImageData object representing the underlying pixel data for a specified portion of the canvas.
         /// </summary>
         /// <param name="sx">The x-axis coordinate of the top-left corner of the rectangle from which the ImageData will be extracted.</param>
@@ -752,6 +743,7 @@ namespace SpawnDev.BlazorJS.JSObjects
         /// <param name="settings">An optional ImageDataSettings object to specify additional settings.</param>
         /// <returns>An ImageData object representing the underlying pixel data for the specified portion of the canvas.</returns>
         public ImageData GetImageData(double sx, double sy, double sw, double sh, ImageDataSettings settings) => JSRef!.Call<ImageData>("getImageData", sx, sy, sw, sh, settings);
+
         /// <summary>
         /// The CanvasRenderingContext2D.getContextAttributes() method of the Canvas 2D API returns an object that contains the actual context parameters.
         /// </summary>

--- a/SpawnDev.BlazorJS/JSObjects/ImageData.cs
+++ b/SpawnDev.BlazorJS/JSObjects/ImageData.cs
@@ -11,69 +11,83 @@ namespace SpawnDev.BlazorJS.JSObjects
     public class ImageData : JSObject
     {
         #region Constructors
+
         /// <summary>
         /// Deserialization constructor
         /// </summary>
         /// <param name="_ref"></param>
         public ImageData(IJSInProcessObjectReference _ref) : base(_ref) { }
+
         /// <summary>
         /// The ImageData() constructor returns a newly instantiated ImageData object built from the typed array given and having the specified width and height.<br/>
         /// This constructor is the preferred way of creating such an object in a Worker.
         /// </summary>
         /// <param name="width">An unsigned long representing the width of the image.</param>
         /// <param name="height">An unsigned long representing the height of the image. This value is optional if an array is given: the height will be inferred from the array's size and the given width.</param>
-        public ImageData(int width, int height) : base(JS.New(nameof(ImageData), width, height)) { }
+        public ImageData(double width, double height) : base(JS.New(nameof(ImageData), width, height)) { }
+
         /// <summary>
         /// The ImageData() constructor returns a newly instantiated ImageData object built from the typed array given and having the specified width and height.<br/>
         /// This constructor is the preferred way of creating such an object in a Worker.
         /// </summary>
-        /// <param name="width">An unsigned long representing the width of the image.</param>
-        /// <param name="height">An unsigned long representing the height of the image. This value is optional if an array is given: the height will be inferred from the array's size and the given width.</param>
-        /// <param name="settings">ImageDataSettings object</param>
-        public ImageData(int width, int height, ImageDataSettings settings) : base(JS.New(nameof(ImageData), width, height, settings)) { }
-        /// <summary>
-        /// The ImageData() constructor returns a newly instantiated ImageData object built from the typed array given and having the specified width and height.<br/>
-        /// This constructor is the preferred way of creating such an object in a Worker.
-        /// </summary>
-        /// <param name="dataArray">A Uint8ClampedArray containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified width and height will be created.</param>
-        /// <param name="width">An unsigned long representing the width of the image.</param>
-        public ImageData(Uint8ClampedArray dataArray, int width) : base(JS.New(nameof(ImageData), dataArray, width)) { }
-        /// <summary>
-        /// The ImageData() constructor returns a newly instantiated ImageData object built from the typed array given and having the specified width and height.<br/>
-        /// This constructor is the preferred way of creating such an object in a Worker.
-        /// </summary>
-        /// <param name="dataArray">A Uint8ClampedArray containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified width and height will be created.</param>
-        /// <param name="width">An unsigned long representing the width of the image.</param>
-        /// <param name="height">An unsigned long representing the height of the image. This value is optional if an array is given: the height will be inferred from the array's size and the given width.</param>
-        public ImageData(Uint8ClampedArray dataArray, int width, int height) : base(JS.New(nameof(ImageData), dataArray, width, height)) { }
-        /// <summary>
-        /// The ImageData() constructor returns a newly instantiated ImageData object built from the typed array given and having the specified width and height.<br/>
-        /// This constructor is the preferred way of creating such an object in a Worker.
-        /// </summary>
-        /// <param name="dataArray">A Uint8ClampedArray containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified width and height will be created.</param>
         /// <param name="width">An unsigned long representing the width of the image.</param>
         /// <param name="height">An unsigned long representing the height of the image. This value is optional if an array is given: the height will be inferred from the array's size and the given width.</param>
         /// <param name="settings">ImageDataSettings object</param>
-        public ImageData(Uint8ClampedArray dataArray, int width, int height, ImageDataSettings settings) : base(JS.New(nameof(ImageData), dataArray, width, height, settings)) { }
+        public ImageData(double width, double height, ImageDataSettings settings) : base(JS.New(nameof(ImageData), width, height, settings)) { }
+
+        /// <summary>
+        /// The ImageData() constructor returns a newly instantiated ImageData object built from the typed array given and having the specified width and height.<br/>
+        /// This constructor is the preferred way of creating such an object in a Worker.
+        /// </summary>
+        /// <param name="dataArray">A Uint8ClampedArray containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified width and height will be created.</param>
+        /// <param name="width">An unsigned long representing the width of the image.</param>
+        public ImageData(Uint8ClampedArray dataArray, double width) : base(JS.New(nameof(ImageData), dataArray, width)) { }
+
+        /// <summary>
+        /// The ImageData() constructor returns a newly instantiated ImageData object built from the typed array given and having the specified width and height.<br/>
+        /// This constructor is the preferred way of creating such an object in a Worker.
+        /// </summary>
+        /// <param name="dataArray">A Uint8ClampedArray containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified width and height will be created.</param>
+        /// <param name="width">An unsigned long representing the width of the image.</param>
+        /// <param name="height">An unsigned long representing the height of the image. This value is optional if an array is given: the height will be inferred from the array's size and the given width.</param>
+        public ImageData(Uint8ClampedArray dataArray, double width, double height) : base(JS.New(nameof(ImageData), dataArray, width, height)) { }
+
+        /// <summary>
+        /// The ImageData() constructor returns a newly instantiated ImageData object built from the typed array given and having the specified width and height.<br/>
+        /// This constructor is the preferred way of creating such an object in a Worker.
+        /// </summary>
+        /// <param name="dataArray">A Uint8ClampedArray containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified width and height will be created.</param>
+        /// <param name="width">An unsigned long representing the width of the image.</param>
+        /// <param name="height">An unsigned long representing the height of the image. This value is optional if an array is given: the height will be inferred from the array's size and the given width.</param>
+        /// <param name="settings">ImageDataSettings object</param>
+        public ImageData(Uint8ClampedArray dataArray, double width, double height, ImageDataSettings settings) : base(JS.New(nameof(ImageData), dataArray, width, height, settings)) { }
+
         #endregion
+
         #region Properties
+
         /// <summary>
         /// A Uint8ClampedArray representing a one-dimensional array containing the data in the RGBA order, with integer values between 0 and 255 (inclusive). The order goes by rows from the top-left pixel to the bottom-right.
         /// </summary>
         public Uint8ClampedArray Data => JSRef!.Get<Uint8ClampedArray>("data");
+
         /// <summary>
         /// A string indicating the color space of the image data.
         /// </summary>
         public string ColorSpace => JSRef!.Get<string>("colorSpace");
+
         /// <summary>
         /// An unsigned long representing the actual height, in pixels, of the ImageData.
         /// </summary>
         public int Height => JSRef!.Get<int>("height");
+
         /// <summary>
         /// An unsigned long representing the actual width, in pixels, of the ImageData.
         /// </summary>
         public int Width => JSRef!.Get<int>("width");
+
         #endregion
+
         /// <summary>
         /// Creates an ImageData from a Uint8Array's view on its underlying ArrayBuffer.<br/>
         /// This is a zero-copy operation. The ImageData.Data property, a Uint8ClampedArray, will point to the same section of the same ArrayBuffer as the source.
@@ -88,6 +102,7 @@ namespace SpawnDev.BlazorJS.JSObjects
             using var rgbaUint8ClampedArray = new Uint8ClampedArray(arrayBuffer, rgbaUint8Array.ByteOffset, rgbaUint8Array.ByteLength);
             return new ImageData(rgbaUint8ClampedArray, width, height);
         }
+
         /// <summary>
         /// Creates an ImageData from a byte[]
         /// </summary>


### PR DESCRIPTION
I've corrected the data type used throughout CanvasRenderingContext2D and the related ImageData class so it's all Double like it should be (number in TypeScript/Javascript is equivalent to Double, not int).

Making these changes i noticed there were some additional overloads with double for some methods that lacked the full XML documentation so i removed them, there was also a overload that was less descriptive i chose to remove in favor of the more informational version.

NOTE: these are breaking changes (binary level but also partially the removal of some overloads causing some parameters to change their names potentially).